### PR TITLE
feat: add inherits polyfill.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ build({
 - `fs`¹ as implemented in [`browserify-fs`](https://www.npmjs.com/package/browserify-fs)
 - `http` as implemented in [`stream-http`](https://www.npmjs.com/package/stream-http)
 - `https` as implemented in [`stream-http`](https://www.npmjs.com/package/stream-http)
+- `inherits` as implemented in [`inherits`](https://www.npmjs.com/package/inherits)
 - `os` as implemented in [`os`](https://www.npmjs.com/package/os)
 - `path` as implemented in [`path`](https://www.npmjs.com/package/path)
 - `process` as implemented in [`process-es6`](https://www.npmjs.com/package/process-es6)

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
 		"domain-browser": "^4.22.0",
 		"events": "^3.3.0",
 		"import-meta-resolve": "^2.1.0",
+		"inherits": "^2.0.4",
 		"os-browserify": "^0.3.0",
 		"path": "^0.12.7",
 		"process-es6": "^0.11.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ specifiers:
   eslint: ^8.24.0
   events: ^3.3.0
   import-meta-resolve: ^2.1.0
+  inherits: ^2.0.4
   os-browserify: ^0.3.0
   path: ^0.12.7
   prettier: ^2.7.1
@@ -44,6 +45,7 @@ dependencies:
   domain-browser: 4.22.0
   events: 3.3.0
   import-meta-resolve: 2.1.0
+  inherits: 2.0.4
   os-browserify: 0.3.0
   path: 0.12.7
   process-es6: 0.11.6

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ export interface PolyfillNodeOptions {
 		fs?: boolean | "empty";
 		http?: boolean | "empty";
 		https?: boolean | "empty";
+		inherits?: boolean | "empty";
 		os?: boolean | "empty";
 		path?: boolean | "empty";
 		process?: boolean | "empty";
@@ -166,6 +167,7 @@ export interface PolyfillNodeForDenoOptions {
 		"fs/promises"?: boolean | "empty";
 		http?: boolean | "npm" | "empty";
 		https?: boolean | "npm" | "empty";
+		inherits?: boolean | "npm" | "empty";
 		module?: boolean | "empty";
 		net?: boolean | "empty";
 		os?: boolean | "npm" | "empty";
@@ -305,6 +307,7 @@ const npmPolyfillMap: Record<string, string> = {
 	fs: "browserify-fs/index.js",
 	http: "stream-http/index.js",
 	https: "stream-http/index.js",
+	inherits: "inherits/inherits_browser.js",
 	os: "os-browserify/browser.js",
 	path: "path/path.js",
 	process: "process-es6/browser.js",
@@ -346,6 +349,7 @@ const denoPolyfills = new Set([
 	"fs",
 	"fs/promises",
 	"http",
+	"inherits",
 	"module",
 	"net",
 	"os",


### PR DESCRIPTION
I was having issues with inherits polyfill. I've forked this repo and added inherits npm package and now it works as intended.

```
  The plugin "node-polyfills" was triggered by this import

    node_modules/hash.js/lib/hash/utils.js:4:23:
      4 │ var inherits = require('inherits');
        ╵                        ~~~~~~~~~~

X [ERROR] Cannot find polyfill for inherits [plugin node-polyfills]

    node_modules/esbuild-plugin-polyfill-node/dist/index.cjs:73:16:
      73 │           throw new Error("Cannot find polyfill for " + moduleName);
         ╵          
         ```