### PR TITLE
Replace uses of `deno.land/std/node/{}.ts` with native `node:{}`

### DIFF
--- a/polyfills/global-for-deno.js
+++ b/polyfills/global-for-deno.js
@@ -1,5 +1,4 @@
-import "virtual:deno-std-node-global";
-export const process = globalThis.process;
-export const Buffer = globalThis.Buffer;
-export const setImmediate = globalThis.setImmediate;
-export const clearImmediate = globalThis.clearImmediate;
+import * as process from "virtual:node:process";
+export { process };
+export { Buffer } from "virtual:node:buffer";
+export { setImmediate, clearImmediate } from "virtual:node:timers";

--- a/src/index.ts
+++ b/src/index.ts
@@ -388,11 +388,12 @@ const jspmPolyiflls = new Set([
 const denoPolyfills = new Set([
 	"assert",
 	"assert/strict",
+	"async_hooks",
 	"buffer",
+	"child_process",
 	"console",
 	"constants",
 	"crypto",
-	"child_process",
 	"dns",
 	"events",
 	"fs",
@@ -415,11 +416,6 @@ const denoPolyfills = new Set([
 	"url",
 	"util",
 	"worker_threads",
-	
-
-	// ===
-
-	"async_hooks",
 ]);
 
 let importMetaResolve: typeof import("import-meta-resolve").resolve;


### PR DESCRIPTION
Updates to the latest [Deno Node API compatability](https://docs.deno.com/runtime/manual/node/compatibility).