### PR TITLE
Fix globals polyfill not being inserted

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -180,7 +180,9 @@ export function polyfillNode(options: PolyfillNodeOptions = {}): Plugin {
 				build.initialOptions.inject = build.initialOptions.inject || [];
 
 				if (global) {
-					resolve(dirname(filename), "../polyfills/global.js");
+					build.initialOptions.inject.push(
+						resolve(dirname(filename), "../polyfills/global.js"),
+					);
 				}
 
 				if (__dirname) {
@@ -190,7 +192,9 @@ export function polyfillNode(options: PolyfillNodeOptions = {}): Plugin {
 				}
 
 				if (__filename) {
-					resolve(dirname(filename), "../polyfills/__filename.js");
+					build.initialOptions.inject.push(
+						resolve(dirname(filename), "../polyfills/__filename.js"),
+					);
 				}
 
 				if (buffer) {


### PR DESCRIPTION
Fix issue #22 
This fix inserts the globals polyfill when specified with the config, unlike how it currently is.