### PR TITLE
Fix Deprecation Warning: fs.Stats Constructor Is Deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 	"author": "Fatih Aygün <cyco130@gmail.com>",
 	"license": "MIT",
 	"dependencies": {
-		"@jspm/core": "^2.0.1",
-		"import-meta-resolve": "^3.0.0"
+		"@jspm/core": "2.1.0",
+		"import-meta-resolve": "4.1.0"
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,15 @@
 {
 	"compilerOptions": {
 		"strict": true,
-		"module": "ES2020",
+		"module": "NodeNext",
 		"lib": ["ES2020", "ES2021.String"],
 		"esModuleInterop": true,
-		"target": "es6",
-		"moduleResolution": "node",
+		"target": "ES2020",
+		"moduleResolution": "NodeNext",
 		"types": ["node"],
 		"skipLibCheck": true,
-		"resolveJsonModule": true
+		"resolveJsonModule": true,
+		"declaration": true
 	},
 	"include": ["src/**/*.ts"]
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,5 +6,6 @@ export default defineConfig([
 		format: ["esm", "cjs"],
 		target: "node14",
 		dts: true,
+		shims: true
 	},
 ]);


### PR DESCRIPTION
### Error:
`(node:72235) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.`

### Changes:
1. **`package.json`**:
   - Updated `@jspm/core` to version `2.1.0`.
   - Updated `import-meta-resolve` to version `4.1.0`.

2. **`tsconfig.json`**:
   - Changed `module` to `NodeNext` for better Node.js compatibility.
   - Updated `target` to `ES2020`.
   - Added `declaration: true` to generate type declaration files.

3. **`tsup.config.ts`**:
   - Added `shims: true` to include necessary Node.js polyfills.